### PR TITLE
add tt dev environment, add tt compat layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 test/
 *.so
+.rocks
+.cache

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SRC = src/luasimdjson.cpp src/simdjson.cpp
+_SRC = src/luasimdjson.cpp src/simdjson.cpp $(SRC)
 INCLUDE = -I$(LUA_INCDIR)
 LIBS_PATH = -L$(LUA_LIBDIR)
 LIBS = -lpthread
@@ -7,10 +7,19 @@ FLAGS = -std=c++11 -Wall $(LIBFLAG) $(CFLAGS)
 all: simdjson.so
 
 simdjson.so:
-	$(CXX) $(SRC) $(FLAGS) $(INCLUDE) $(LIBS_PATH) $(LIBS) -o $@
+	$(CXX) $(_SRC) $(FLAGS) $(INCLUDE) $(LIBS_PATH) $(LIBS) -o $@
 
 clean:
-	rm *.so
+	-rm *.so
 
 install: simdjson.so
 	cp simdjson.so $(INST_LIBDIR)
+
+build: clean
+	tarantoolctl rocks make lua-simdjson-pico.scm-1.rockspec
+
+local-env:
+	./dev_deps.sh
+
+test: build
+	.rocks/bin/luatest -v tests/

--- a/dev_deps.sh
+++ b/dev_deps.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Call this script to install dependencies for development purposes.
+
+set -e
+
+# Test dependencies:
+tarantoolctl rocks install luacheck 0.26.0
+tarantoolctl rocks install luatest 0.5.6

--- a/lua-simdjson-pico.0.0.0-0.rockspec.template
+++ b/lua-simdjson-pico.0.0.0-0.rockspec.template
@@ -1,8 +1,10 @@
+-- Rockspecs template for picodata version.
+-- Copy it, replace tag in source and change version.
 package="lua-simdjson"
-version="pico.0.0.3-1"
+version="pico.0.0.0-0"
 source = {
    url = "git://github.com/picodata/lua-simdjson",
-   tag = "0.0.3"
+   tag = "0.0.0"
 }
 description = {
    summary = "This is a simple Lua binding for simdjson",

--- a/lua-simdjson-pico.0.0.3-1.rockspec
+++ b/lua-simdjson-pico.0.0.3-1.rockspec
@@ -1,0 +1,39 @@
+package="lua-simdjson"
+version="pico.0.0.3-1"
+source = {
+   url = "git://github.com/picodata/lua-simdjson",
+   tag = "0.0.3"
+}
+description = {
+   summary = "This is a simple Lua binding for simdjson",
+   detailed = [[
+      This is a c++ binding to simdjson for parsing JSON very quickly.
+   ]],
+   homepage = "https://github.com/picodata/lua-simdjson",
+   license = "Apache-2.0"
+}
+dependencies = {
+   "lua >= 5.1, < 5.5"
+}
+
+build = {
+   type = "make",
+   build_variables = {
+      CFLAGS="$(CFLAGS) -D TT_COMPAT",
+      -- add compat sources as well(normally they are excluded).
+      SRC="src/tt_compat.cpp",
+      LIBFLAG="$(LIBFLAG)",
+      LUA_LIBDIR="$(LUA_LIBDIR)",
+      LUA_BINDIR="$(LUA_BINDIR)",
+      LUA_INCDIR="$(LUA_INCDIR)",
+      LUA="$(LUA)",
+   },
+   install_variables = {
+      INST_PREFIX="$(PREFIX)",
+      INST_BINDIR="$(BINDIR)",
+      INST_LIBDIR="$(LIBDIR)",
+      INST_LUADIR="$(LUADIR)",
+      INST_CONFDIR="$(CONFDIR)",
+   },
+}
+

--- a/lua-simdjson-pico.scm-1.rockspec
+++ b/lua-simdjson-pico.scm-1.rockspec
@@ -1,0 +1,38 @@
+package="lua-simdjson"
+version="pico.scm-1"
+source = {
+   url = "/dev/null",
+}
+description = {
+   summary = "This is a simple Lua binding for simdjson",
+   detailed = [[
+      This is a c++ binding to simdjson for parsing JSON very quickly.
+   ]],
+   homepage = "https://github.com/FourierTransformer/lua-simdjson",
+   license = "Apache-2.0"
+}
+dependencies = {
+   "lua >= 5.1, < 5.5"
+}
+
+build = {
+   type = "make",
+   build_variables = {
+      CFLAGS="$(CFLAGS) -D TT_COMPAT",
+      -- add compat sources as well(normally they are excluded).
+      SRC="src/tt_compat.cpp",
+      LIBFLAG="$(LIBFLAG)",
+      LUA_LIBDIR="$(LUA_LIBDIR)",
+      LUA_BINDIR="$(LUA_BINDIR)",
+      LUA_INCDIR="$(LUA_INCDIR)",
+      LUA="$(LUA)",
+   },
+   install_variables = {
+      INST_PREFIX="$(PREFIX)",
+      INST_BINDIR="$(BINDIR)",
+      INST_LIBDIR="$(LIBDIR)",
+      INST_LUADIR="$(LUADIR)",
+      INST_CONFDIR="$(CONFDIR)",
+   },
+}
+

--- a/lua-simdjson-scm-2.rockspec
+++ b/lua-simdjson-scm-2.rockspec
@@ -1,0 +1,35 @@
+-- Is needed for CI - to test ordinary(without TT compat) installation works.
+package="lua-simdjson"
+version="scm-2"
+source = {
+   url = "/dev/null",
+}
+description = {
+   summary = "This is a simple Lua binding for simdjson",
+   detailed = [[
+      This is a c++ binding to simdjson for parsing JSON very quickly.
+   ]],
+   homepage = "https://github.com/FourierTransformer/lua-simdjson",
+   license = "Apache-2.0"
+}
+dependencies = {
+   "lua >= 5.1, < 5.5"
+}
+build = {
+   type = "make",
+   build_variables = {
+      CFLAGS="$(CFLAGS)",
+      LIBFLAG="$(LIBFLAG)",
+      LUA_LIBDIR="$(LUA_LIBDIR)",
+      LUA_BINDIR="$(LUA_BINDIR)",
+      LUA_INCDIR="$(LUA_INCDIR)",
+      LUA="$(LUA)",
+   },
+   install_variables = {
+      INST_PREFIX="$(PREFIX)",
+      INST_BINDIR="$(BINDIR)",
+      INST_LIBDIR="$(LIBDIR)",
+      INST_LUADIR="$(LUADIR)",
+      INST_CONFDIR="$(CONFDIR)",
+   },
+}

--- a/spec/compile_spec.lua
+++ b/spec/compile_spec.lua
@@ -1,5 +1,6 @@
 local simdjson = require("simdjson")
 local cjson = require("cjson")
+local consts = require("spec.consts")
 
 local function loadFile(textFile)
     local file = io.open(textFile, "r")
@@ -9,35 +10,10 @@ local function loadFile(textFile)
     return allLines
 end
 
-
-local files = {
-	"apache_builds.json",
-	"canada.json",
-	"citm_catalog.json",
-	"github_events.json",
-	"google_maps_api_compact_response.json",
-	"google_maps_api_response.json",
-	"gsoc-2018.json",
-	"instruments.json",
-	"marine_ik.json",
-	"mesh.json",
-	"mesh.pretty.json",
-	"numbers.json",
-	"random.json",
-	"repeat.json",
-	"twitter_timeline.json",
-	"update-center.json",
-	"small/adversarial.json",
-	"small/demo.json",
-	"small/flatadversarial.json",
-	"small/smalldemo.json",
-	"small/truenull.json"
-}
-
 describe("Make sure everything compiled correctly", function()
-	for _, file in ipairs(files) do
+	for _, file in ipairs(consts.jsonexamples) do
 		it("should parse the file: " .. file, function()
-			local fileContents = loadFile("jsonexamples/" .. file)
+			local fileContents = loadFile(file)
 			assert.are.same(cjson.decode(fileContents), simdjson.parse(fileContents))
 		end)
 	end

--- a/spec/consts.lua
+++ b/spec/consts.lua
@@ -1,0 +1,35 @@
+local jsonexamples = {
+	"apache_builds.json",
+	"canada.json",
+	"citm_catalog.json",
+	"github_events.json",
+	"google_maps_api_compact_response.json",
+	"google_maps_api_response.json",
+	"gsoc-2018.json",
+	"instruments.json",
+	"marine_ik.json",
+	"mesh.json",
+	"mesh.pretty.json",
+	"numbers.json",
+	"random.json",
+	"repeat.json",
+	"twitter_timeline.json",
+	"update-center.json",
+	"small/adversarial.json",
+	"small/demo.json",
+	"small/flatadversarial.json",
+	"small/smalldemo.json",
+	"small/truenull.json"
+}
+
+local function jsonexample_filepath(filename)
+  return "jsonexamples/" .. filename
+end
+
+for idx, filename in ipairs(jsonexamples) do
+  jsonexamples[idx] = jsonexample_filepath(filename)
+end
+
+return {
+  jsonexamples = jsonexamples
+}

--- a/src/luasimdjson.cpp
+++ b/src/luasimdjson.cpp
@@ -283,7 +283,7 @@ int luaopen_simdjson (lua_State *L) {
     lua_newtable(L);
     luaL_setfuncs (L, luasimdjson, 0);
 
-    lua_pushlightuserdata(L, NULL);
+    lua_pushnull(L);
     lua_setfield(L, -2, "null");
 
     lua_pushliteral(L, LUA_SIMDJSON_NAME);

--- a/src/luasimdjson.cpp
+++ b/src/luasimdjson.cpp
@@ -4,11 +4,25 @@
 #include "simdjson.h"
 #include "luasimdjson.h"
 
+#ifdef TT_COMPAT
+#include "tt_compat.h"
+#endif
+
 #define LUA_SIMDJSON_NAME       "simdjson"
 #define LUA_SIMDJSON_VERSION    "0.0"
 
 using namespace simdjson;
 
+/* Push "null" value to the stack.
+ * By default it is lightuserdata, but in tarantool world it is cdata void*, hence such function exists.
+*/
+static void lua_pushnull(lua_State *L) {
+    #ifdef TT_COMPAT
+      tt_lua_pushnull(L);
+    #else
+      lua_pushlightuserdata(L, NULL);
+    #endif
+}
 
 #if !defined(luaL_newlibtable) && (!defined LUA_VERSION_NUM || LUA_VERSION_NUM<=501)
 /*
@@ -38,6 +52,12 @@ void convert_element_to_table(lua_State *L, dom::element element) {
       {
           int count = 1;
           lua_newtable(L);
+
+          #ifdef TT_COMPAT
+            tt_lua_push_serialize_mt(L, SER_MARKER_SEQ);
+            lua_setmetatable(L, -2);
+          #endif
+
           for (dom::element child : dom::array(element)) {
             lua_pushinteger(L, count);
             convert_element_to_table(L, child);
@@ -49,6 +69,12 @@ void convert_element_to_table(lua_State *L, dom::element element) {
     
     case dom::element_type::OBJECT:
       lua_newtable(L);
+
+      #ifdef TT_COMPAT
+        tt_lua_push_serialize_mt(L, SER_MARKER_MAP);
+        lua_setmetatable(L, -2);
+      #endif
+
       for (dom::key_value_pair field : dom::object(element)) {
 
         std::string_view view(field.key);
@@ -83,7 +109,7 @@ void convert_element_to_table(lua_State *L, dom::element element) {
       break;
     
     case dom::element_type::NULL_VALUE:
-      lua_pushlightuserdata(L, NULL);
+      lua_pushnull(L);
       break;
   }
 }
@@ -244,6 +270,9 @@ static const struct luaL_Reg arraylib_m [] = {
 };
 
 int luaopen_simdjson (lua_State *L) {
+    #ifdef TT_COMPAT
+      tt_compat_init(L);
+    #endif
     luaL_newmetatable(L, LUA_MYOBJECT);
      lua_pushvalue(L, -1); /* duplicates the metatable */
     lua_setfield(L, -2, "__index");

--- a/src/tt_compat.cpp
+++ b/src/tt_compat.cpp
@@ -1,13 +1,11 @@
 #include <lua.hpp>
 #include <lauxlib.h>
-#include <string>
 #include "tt_compat.h"
 
 char* SER_MARKER_MAP = (char*)"map";
 char* SER_MARKER_SEQ = (char*)"seq";
 
-// Variable is needed to avoid collisions in LUA_REGISTRY.
-static const char TT_NULL_ADDR = 't';
+const char TT_NULL_ADDR = 'T';
 
 /* Mimics tarantool's cjson NULL, catches and sets it as global variable for future usage.
  * Internally it loads json library, then extracts the "null" value from it and stores it in a registry.
@@ -17,11 +15,6 @@ static void tt_lua_createnull(lua_State *L) {
     lua_pushlightuserdata(L, (void *)&TT_NULL_ADDR);
     lua_getfield(L, -2, "null");
     lua_settable(L, LUA_REGISTRYINDEX);
-}
-
-void tt_lua_pushnull(lua_State *L) {
-  lua_pushlightuserdata(L, (void *)&TT_NULL_ADDR);
-  lua_gettable(L, LUA_REGISTRYINDEX);
 }
 
 void tt_compat_init(lua_State *L) {

--- a/src/tt_compat.cpp
+++ b/src/tt_compat.cpp
@@ -21,9 +21,3 @@ void tt_compat_init(lua_State *L) {
   tt_lua_createnull(L);
 }
 
-void tt_lua_push_serialize_mt(lua_State *L, char* marker) {
-  lua_createtable(L, 0, 1);
-  lua_pushstring(L, "__serialize");
-  lua_pushstring(L, marker);
-  lua_settable(L, -3);
-}

--- a/src/tt_compat.cpp
+++ b/src/tt_compat.cpp
@@ -1,0 +1,36 @@
+#include <lua.hpp>
+#include <lauxlib.h>
+#include <string>
+#include "tt_compat.h"
+
+char* SER_MARKER_MAP = (char*)"map";
+char* SER_MARKER_SEQ = (char*)"seq";
+
+// Variable is needed to avoid collisions in LUA_REGISTRY.
+static const char TT_NULL_ADDR = 't';
+
+/* Mimics tarantool's cjson NULL, catches and sets it as global variable for future usage.
+ * Internally it loads json library, then extracts the "null" value from it and stores it in a registry.
+*/
+static void tt_lua_createnull(lua_State *L) {
+    luaL_register(L, "json", 0);
+    lua_pushlightuserdata(L, (void *)&TT_NULL_ADDR);
+    lua_getfield(L, -2, "null");
+    lua_settable(L, LUA_REGISTRYINDEX);
+}
+
+void tt_lua_pushnull(lua_State *L) {
+  lua_pushlightuserdata(L, (void *)&TT_NULL_ADDR);
+  lua_gettable(L, LUA_REGISTRYINDEX);
+}
+
+void tt_compat_init(lua_State *L) {
+  tt_lua_createnull(L);
+}
+
+void tt_lua_push_serialize_mt(lua_State *L, char* marker) {
+  lua_createtable(L, 0, 1);
+  lua_pushstring(L, "__serialize");
+  lua_pushstring(L, marker);
+  lua_settable(L, -3);
+}

--- a/src/tt_compat.h
+++ b/src/tt_compat.h
@@ -6,11 +6,16 @@
  */
 void tt_compat_init(lua_State *L);
 
+// Variable is needed to avoid collisions in LUA_REGISTRY.
+extern const char TT_NULL_ADDR;
 
 /* Pushes tarantool's null onto the stack.
  * It requires `tt_lua_init` to be called first.
  */
-void tt_lua_pushnull(lua_State *L);
+inline void tt_lua_pushnull(lua_State *L) {
+  lua_pushlightuserdata(L, (void *)&TT_NULL_ADDR);
+  lua_gettable(L, LUA_REGISTRYINDEX);
+}
 
 extern char* SER_MARKER_SEQ;
 extern char* SER_MARKER_MAP;

--- a/src/tt_compat.h
+++ b/src/tt_compat.h
@@ -1,0 +1,25 @@
+#include <lua.hpp>
+#include <lauxlib.h>
+
+/* Initializes needed consts for future work.
+ * Intended to be called on the Lua module init.
+ */
+void tt_compat_init(lua_State *L);
+
+
+/* Pushes tarantool's null onto the stack.
+ * It requires `tt_lua_init` to be called first.
+ */
+void tt_lua_pushnull(lua_State *L);
+
+extern char* SER_MARKER_SEQ;
+extern char* SER_MARKER_MAP;
+
+/* Push metatable with given `__serialize` marker onto the stack.
+ * As empty table in lua can be treated as both empty map and empty table, we need to somehow distinguish them.
+ * This adds key `__serialize` to the resulting metatable, which might be one of following markers:
+ * 1) `seq`: table was an array in the original json;
+ * 2) `map`: table was a table in the original json.
+ * `marker` param must be one of defined `SER_MARKER_*` consts.
+ */
+void tt_lua_push_serialize_mt(lua_State *L, char* marker);

--- a/src/tt_compat.h
+++ b/src/tt_compat.h
@@ -27,4 +27,9 @@ extern char* SER_MARKER_MAP;
  * 2) `map`: table was a table in the original json.
  * `marker` param must be one of defined `SER_MARKER_*` consts.
  */
-void tt_lua_push_serialize_mt(lua_State *L, char* marker);
+inline void tt_lua_push_serialize_mt(lua_State *L, char* marker) {
+  lua_createtable(L, 0, 1);
+  lua_pushstring(L, "__serialize");
+  lua_pushstring(L, marker);
+  lua_settable(L, -3);
+}

--- a/tests/tarantool_test.lua
+++ b/tests/tarantool_test.lua
@@ -1,0 +1,40 @@
+local t = require("luatest")
+local simdjson = require("simdjson")
+local g = t.group("tarantool")
+local specs = require("spec.consts")
+local tt_json = require("json")
+local fio = require("fio")
+
+local function load_file(filepath)
+    local file, err = fio.open(filepath, { "O_RDONLY" })
+    t.assert_equals(err, nil)
+    t.assert_not_equals(file, nil)
+    local allLines = file:read()
+    file:close()
+    return allLines
+end
+
+g.test_nulls_are_same = function ()
+  local raw_json = '[{"first_null": null, "second_null": null, "nulls_array": [null, {"key": null}]}]'
+  t.assert_equals(simdjson.parse(raw_json), tt_json.decode(raw_json))
+end
+
+g.test_compat_with_tarantool_json = function()
+  for _, path in ipairs(specs.jsonexamples) do
+    local lines = load_file(path)
+    t.assert_equals(simdjson.parse(lines), tt_json.decode(lines))
+  end
+end
+
+g.test_serialize_markers = function ()
+  local result = simdjson.parse('{"nested": {"emptyMap": {}}, "emptyArray": []}')
+  t.assert_equals(getmetatable(result), {__serialize = "map"})
+  t.assert_equals(getmetatable(result.emptyArray), {__serialize = "seq"})
+  t.assert_equals(getmetatable(result.nested), {__serialize = "map"})
+  t.assert_equals(getmetatable(result.nested.emptyMap), {__serialize = "map"})
+
+	local result = simdjson.parse('[{"emptyMap": {}, "emptyArray": []}]')
+  t.assert_equals(getmetatable(result), {__serialize = "seq"})
+  t.assert_equals(getmetatable(result[1].emptyMap), {__serialize = "map"})
+  t.assert_equals(getmetatable(result[1].emptyArray), {__serialize = "seq"})
+end


### PR DESCRIPTION
It is needed to test compatibility with tarantool environment, and ensure it correctly sets the `__serialize` marker.

It also simplifies the dev process for tarantool users.